### PR TITLE
remove MedCo query text + auto-cut the text in the pdf

### DIFF
--- a/src/app/modules/gb-explore-module/gb-explore.component.html
+++ b/src/app/modules/gb-explore-module/gb-explore.component.html
@@ -3,9 +3,6 @@
 
 
   <div class="gb-data-selection-accordion-header">
-    <div class="gb-data-selection-accordion-sub-header-1">
-      Define your MedCo Explore query
-    </div>
     <div class="gb-data-selection-accordion-sub-header-2">
       <div style="display: flex;">
         <span style="display: flex; align-items: center;" *ngIf="!userHasExploreStatsRole()">

--- a/src/app/modules/gb-explore-statistics-module/panel-components/gb-explore-statistics-results/gb-explore-statistics-results.component.ts
+++ b/src/app/modules/gb-explore-statistics-module/panel-components/gb-explore-statistics-results/gb-explore-statistics-results.component.ts
@@ -68,11 +68,15 @@ export class GbExploreStatisticsResultsComponent implements AfterViewInit, OnDes
 
   private _displayLoadingIcon = false
 
+  private _maxLineSize = 124
+
   private exportPDFSubscription: Subscription
 
   // instantiated reference interval components visible within the view of the GbExploreStatisticsResultsComponent
   private refIntervalsComponents: ReferenceIntervalComponent[]
   private rootConstraint: CombinationConstraint;
+
+  
 
   constructor(private exploreStatisticsService: ExploreStatisticsService,
     private authService: AuthenticationService,
@@ -120,7 +124,7 @@ export class GbExploreStatisticsResultsComponent implements AfterViewInit, OnDes
     const visitor = new PdfExportVisitor();
     const constraintsSummary = this.rootConstraint.accept(visitor);
 
-    constraintsSummary.forEach(line => {
+    constraintsSummary.flatMap(line => GbExploreStatisticsResultsComponent.cutLongLines(line,maxSize)).forEach(line => {
       pdf.addOneLineText(line)
     })
 
@@ -135,8 +139,10 @@ export class GbExploreStatisticsResultsComponent implements AfterViewInit, OnDes
       addEmptyLine()
     }
 
+
     pdf.addOneLineText('Copyright notice', 0, subtitleFontSize)
-    shortCopyright.split('\n').forEach(line => {
+    const maxSize = this._maxLineSize
+    shortCopyright.split('\n').flatMap(line => GbExploreStatisticsResultsComponent.cutLongLines(line,maxSize)).forEach(line => {
       pdf.addOneLineText(line)
     })
 
@@ -177,6 +183,39 @@ export class GbExploreStatisticsResultsComponent implements AfterViewInit, OnDes
 
   get displayLoadingIcon() {
     return this._displayLoadingIcon
+  }
+
+  private  static cutLongLines(text: string, _maxLineSize : number) : string[] {
+    var cutPos = -1
+    if (text.length > _maxLineSize) {
+      cutPos = text.slice(0,_maxLineSize).lastIndexOf(" ")
+      if (cutPos === -1){
+        cutPos = text.slice(0,_maxLineSize).lastIndexOf(":")
+      }
+      if (cutPos === -1){
+        cutPos = text.slice(0,_maxLineSize).lastIndexOf(";")
+      }
+      if (cutPos === -1){
+        cutPos = text.slice(0,_maxLineSize).lastIndexOf(",")
+      }
+      if (cutPos === -1){
+        cutPos = text.slice(0,_maxLineSize).lastIndexOf("/")
+      }
+      if (cutPos === -1){
+        cutPos = text.slice(0,_maxLineSize).lastIndexOf("-")
+      }
+      if (cutPos === -1){
+        cutPos = text.slice(0,_maxLineSize).lastIndexOf("_")
+      }
+      if (cutPos === -1){
+        cutPos = _maxLineSize
+      }
+      cutPos + 1
+      return [text.slice(0, cutPos)].concat(GbExploreStatisticsResultsComponent.cutLongLines(text.slice(cutPos, text.length), _maxLineSize))
+    }
+
+    return [text]
+
   }
 
   ngOnInit() {

--- a/src/app/modules/gb-explore-statistics-module/panel-components/gb-explore-statistics-results/gb-explore-statistics-results.component.ts
+++ b/src/app/modules/gb-explore-statistics-module/panel-components/gb-explore-statistics-results/gb-explore-statistics-results.component.ts
@@ -76,7 +76,38 @@ export class GbExploreStatisticsResultsComponent implements AfterViewInit, OnDes
   private refIntervalsComponents: ReferenceIntervalComponent[]
   private rootConstraint: CombinationConstraint;
 
-  
+  private static cutLongLines(text: string, _maxLineSize: number): string[] {
+    let cutPos = -1
+    if (text.length > _maxLineSize) {
+      cutPos = text.slice(0, _maxLineSize).lastIndexOf(' ')
+      if (cutPos === -1) {
+        cutPos = text.slice(0, _maxLineSize).lastIndexOf(':')
+      }
+      if (cutPos === -1) {
+        cutPos = text.slice(0, _maxLineSize).lastIndexOf(';')
+      }
+      if (cutPos === -1) {
+        cutPos = text.slice(0, _maxLineSize).lastIndexOf(',')
+      }
+      if (cutPos === -1) {
+        cutPos = text.slice(0, _maxLineSize).lastIndexOf('/')
+      }
+      if (cutPos === -1) {
+        cutPos = text.slice(0, _maxLineSize).lastIndexOf('-')
+      }
+      if (cutPos === -1) {
+        cutPos = text.slice(0, _maxLineSize).lastIndexOf('_')
+      }
+      if (cutPos === -1) {
+        cutPos = _maxLineSize
+      }
+      cutPos += 1
+      return [text.slice(0, cutPos)].concat(GbExploreStatisticsResultsComponent.cutLongLines(text.slice(cutPos, text.length), _maxLineSize))
+    }
+
+    return [text]
+
+  }
 
   constructor(private exploreStatisticsService: ExploreStatisticsService,
     private authService: AuthenticationService,
@@ -124,7 +155,7 @@ export class GbExploreStatisticsResultsComponent implements AfterViewInit, OnDes
     const visitor = new PdfExportVisitor();
     const constraintsSummary = this.rootConstraint.accept(visitor);
 
-    constraintsSummary.flatMap(line => GbExploreStatisticsResultsComponent.cutLongLines(line,maxSize)).forEach(line => {
+    constraintsSummary.flatMap(line => GbExploreStatisticsResultsComponent.cutLongLines(line, maxSize)).forEach(line => {
       pdf.addOneLineText(line)
     })
 
@@ -142,7 +173,7 @@ export class GbExploreStatisticsResultsComponent implements AfterViewInit, OnDes
 
     pdf.addOneLineText('Copyright notice', 0, subtitleFontSize)
     const maxSize = this._maxLineSize
-    shortCopyright.split('\n').flatMap(line => GbExploreStatisticsResultsComponent.cutLongLines(line,maxSize)).forEach(line => {
+    shortCopyright.split('\n').flatMap(line => GbExploreStatisticsResultsComponent.cutLongLines(line, maxSize)).forEach(line => {
       pdf.addOneLineText(line)
     })
 
@@ -183,39 +214,6 @@ export class GbExploreStatisticsResultsComponent implements AfterViewInit, OnDes
 
   get displayLoadingIcon() {
     return this._displayLoadingIcon
-  }
-
-  private  static cutLongLines(text: string, _maxLineSize : number) : string[] {
-    var cutPos = -1
-    if (text.length > _maxLineSize) {
-      cutPos = text.slice(0,_maxLineSize).lastIndexOf(" ")
-      if (cutPos === -1){
-        cutPos = text.slice(0,_maxLineSize).lastIndexOf(":")
-      }
-      if (cutPos === -1){
-        cutPos = text.slice(0,_maxLineSize).lastIndexOf(";")
-      }
-      if (cutPos === -1){
-        cutPos = text.slice(0,_maxLineSize).lastIndexOf(",")
-      }
-      if (cutPos === -1){
-        cutPos = text.slice(0,_maxLineSize).lastIndexOf("/")
-      }
-      if (cutPos === -1){
-        cutPos = text.slice(0,_maxLineSize).lastIndexOf("-")
-      }
-      if (cutPos === -1){
-        cutPos = text.slice(0,_maxLineSize).lastIndexOf("_")
-      }
-      if (cutPos === -1){
-        cutPos = _maxLineSize
-      }
-      cutPos + 1
-      return [text.slice(0, cutPos)].concat(GbExploreStatisticsResultsComponent.cutLongLines(text.slice(cutPos, text.length), _maxLineSize))
-    }
-
-    return [text]
-
   }
 
   ngOnInit() {


### PR DESCRIPTION
- removed the Describe the MedCo query line
- automatic new line in PDF when the text exceeds a given length (to be tested in the final result)